### PR TITLE
Add revoked status

### DIFF
--- a/authority.py
+++ b/authority.py
@@ -54,6 +54,23 @@ def number_certificates():
     return bytes(json.dumps({"number": number}), ENCODING)
 
 
+# Return list of certificates with their revoked status (boolean)
+@app.get("/certificates")
+def number_certificates():
+    all_certificate_ids = os.listdir("./trusted_from_authority/")
+    revoked_certificate_ids = os.listdir("./revoked/")
+    return bytes(
+        json.dumps({"certificates": [
+            {
+                "id": certificate_id,
+                "revoked": certificate_id in revoked_certificate_ids,
+            }
+            for certificate_id in sorted(all_certificate_ids)
+        ]}), ENCODING
+    )
+    
+
+
 # Return a list of the revokation tokens previously emitted
 @app.get("/revoked_list")
 def revoked_list():

--- a/index_authority.html
+++ b/index_authority.html
@@ -87,28 +87,32 @@
                 }
             }
 
-
-            fetch(authority_url + "number_certificates")
+            fetch(authority_url + "certificates")
                 .then((response) => response.json())
-                .then((number_certificates) => {
+                .then(({certificates}) => {
                     let thirdparty_list = document.getElementById("thirdparty_list");
-                    let RevokedId = document.getElementById("RevokedId");
+                    let RevokedIds = document.getElementById("RevokedId");
 
                     removeOptions(RevokedId);
                     removeRows(thirdparty_list);
-                    for (let i = 1; i < number_certificates.number + 1; i++) {
-                        let option = document.createElement("option");
-                        option.value = i;
-                        option.text = i;
-                        RevokedId.add(option);
 
-                        let newRow = thirdparty_list.insertRow(-1);
-                        let newCellid = newRow.insertCell(0);
-                        let newTextCelldid = document.createTextNode(i);
-                        newCellid.appendChild(newTextCelldid);
-                    }
-                }
-                );
+                    certificates.forEach(
+                        (certificate) => {
+                            if (!certificate.revoked) {
+                                let option = document.createElement("option");
+                                option.value = certificate.id;
+                                option.text = certificate.id;
+                                RevokedId.add(option);
+                            }
+                            const newRow = thirdparty_list.insertRow(-1);
+                            const newCellid = newRow.insertCell(0);
+                            const emoji = certificate.revoked ? "❌" : "✅"
+                            cellText = `${certificate.id} ${emoji}`
+                            const newTextCelldid = document.createTextNode(cellText);
+                            newCellid.appendChild(newTextCelldid);
+                        }
+                    );
+                });
         }
 
         refresh_values();

--- a/index_trust.html
+++ b/index_trust.html
@@ -150,27 +150,31 @@
             }
 
 
-            fetch(authority_url + "number_certificates")
+            fetch(authority_url + "certificates")
                 .then((response) => response.json())
-                .then((number_certificates) => {
+                .then(({certificates}) => {
                     let trustedId = document.getElementById("trustedId");
                     let thirdparty_list = document.getElementById("thirdparty_list");
 
                     removeOptions(trustedId);
                     removeRows(thirdparty_list);
-                    for (let i = 1; i < number_certificates.number+1; i++) {
-                        let option = document.createElement("option");
-                        option.value = i;
-                        option.text = i;
-                        trustedId.add(option);
 
-                        let newRow = thirdparty_list.insertRow(-1);
-                        let newCellid = newRow.insertCell(0);
-                        let newTextCelldid = document.createTextNode(i);
-                        newCellid.appendChild(newTextCelldid);
-                    }
-                }
-                );
+                    certificates.forEach(
+                        (certificate) => {
+                            let option = document.createElement("option");
+                            option.value = certificate.id;
+                            option.text = certificate.id;
+                            trustedId.add(option);
+
+                            const newRow = thirdparty_list.insertRow(-1);
+                            const newCellid = newRow.insertCell(0);
+                            const emoji = certificate.revoked ? "❌" : "✅"
+                            cellText = `${certificate.id} ${emoji}`
+                            const newTextCelldid = document.createTextNode(cellText);
+                            newCellid.appendChild(newTextCelldid);
+                        }
+                    );
+                });
 
             fetch(age_verifier_url + "list_users")
                 .then((response) => response.json())


### PR DESCRIPTION
## What
This PR enables the user to visualise which trusted third partie certificates are revoked, see screenshot:

<img width="768" alt="Screenshot 2023-05-23 at 17 35 08" src="https://github.com/LINCnil/SigGroup/assets/18351439/cdbdba04-b466-489f-a560-8ebacc759d28">

## How
- Introduce a new `/certificates` route from the on the authority side that returns the authority IDs along with their revocation statuses.
- From the Authority website, add UI logic to show the ✅/❌ status and filter out the already-revoked certificates from the revocation drop-down.
- From the Trusted website, add UI logic to show the ✅/❌ status and filter.

