### PR TITLE
Add executable bit on launch.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ RUN cd SigGroup/ && cp parameters.yaml.docker parameters.yaml && make && pip ins
 
 EXPOSE 9091 9092 9093
 RUN apt-get clean 
+RUN chmod +x /SigGroup/launch.sh
 CMD cd SigGroup/ && LD_LIBRARY_PATH=/usr/local/lib /SigGroup/launch.sh


### PR DESCRIPTION
To fix small issue, just add +x on Launch.sh
```bash
docker run -p 9091:9091 -p 9092:9092 -p 9093:9093 siggroup
/bin/sh: 1: /SigGroup/launch.sh: Permission denied
```


Regards,
W.